### PR TITLE
Fix git exception during build

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -5,6 +5,7 @@ namespace Build;
 use Comodojo\Zip\Zip;
 use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
+use PHPGit\Exception\GitException;
 use PHPGit\Git;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -26,6 +27,10 @@ class Application extends Container
             $this->logger()->error(
                 sprintf('%s thrown: %s', get_class($e), $e->getMessage())
             );
+            $this->logger()->debug($e->getTraceAsString());
+            if ($e instanceof GitException) {
+                $this->logger()->debug($e->getCommandLine());
+            }
             exit(1);
         }
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -109,7 +109,7 @@ class Application extends Container
             $this->repoWordPress()->archive(
                 "$artifacts_path/source.zip",
                 $tag->sha() . ':tests/phpunit',
-                null,
+                '.',
                 [
                     'format' => 'zip',
                 ]

--- a/src/Application.php
+++ b/src/Application.php
@@ -79,19 +79,8 @@ class Application extends Container
         $branch_exists = collect($this->repoPackage()->branch())->contains('name', $tag->majorBranchName());
 
         if ($tag->isDotZero() && ! $branch_exists) {
-            $this->logger()->debug(
-                sprintf("Initializing branch %s for %s", $tag->majorBranchName(), $tag->name)
-            );
-            try {
-                $this->repoPackage()->branch->create($tag->majorBranchName(), 'master');
-            } catch (\Exception $exception) {
-                $this->logger()->error('Failed to create branch for major version. Exception: ' . $exception->getMessage(), [
-                    'tag' => $tag->name,
-                    'major' => $tag->majorVersion,
-                    'branch' => $tag->majorBranchName(),
-                ]);
-                throw $exception;
-            }
+            $this->logger()->debug("Initializing branch for $tag->name");
+            $this->repoPackage()->branch->create($tag->majorBranchName(), 'master');
         }
 
         $this->repoPackage()->checkout($tag->majorBranchName());

--- a/src/Application.php
+++ b/src/Application.php
@@ -74,8 +74,19 @@ class Application extends Container
         $branch_exists = collect($this->repoPackage()->branch())->contains('name', $tag->majorBranchName());
 
         if ($tag->isDotZero() && ! $branch_exists) {
-            $this->logger()->debug("Initializing branch for $tag->name");
-            $this->repoPackage()->branch->create($tag->majorBranchName(), 'master');
+            $this->logger()->debug(
+                sprintf("Initializing branch %s for %s", $tag->majorBranchName(), $tag->name)
+            );
+            try {
+                $this->repoPackage()->branch->create($tag->majorBranchName(), 'master');
+            } catch (\Exception $exception) {
+                $this->logger()->error('Failed to create branch for major version. Exception: ' . $exception->getMessage(), [
+                    'tag' => $tag->name,
+                    'major' => $tag->majorVersion,
+                    'branch' => $tag->majorBranchName(),
+                ]);
+                throw $exception;
+            }
         }
 
         $this->repoPackage()->checkout($tag->majorBranchName());


### PR DESCRIPTION
This PR fixes a git exception which appears to be the result in a change in git version running on the CI server.

As of git 2.16.0, certain commands will fail when a blank string is used as a pathspec where previously this was the same as `.` to reference all files. See https://github.com/git/git/commit/9e4e8a64c2b9043b7ae2b6476efd9214c6738505

The failure was triggered by a `git archive` command internally which was the only command which used this format.

Exception handling has also been improved, particularly for GitExceptions which was instrumental in finding the root cause here.

Strangely, the git version installed in travis builds (`2.21.0`) that were failing has not changed. 🤷‍♂  